### PR TITLE
fix: prompt

### DIFF
--- a/internal/tools/create_template.go
+++ b/internal/tools/create_template.go
@@ -29,7 +29,7 @@ func NewCreateTemplateTool(db *database.Database) (mcp.Tool, server.ToolHandlerF
 		),
 		mcp.WithString("template_code",
 			mcp.Required(),
-			mcp.Description("The smart contract source code template with Go template syntax ({{.VariableName}})"),
+			mcp.Description("The smart contract source code template with Go template syntax ({{.VariableName}}). Don't need to include the contract owner info since it will be set during the deployment. Use msg.sender as the contract owner if not specified."),
 		),
 		mcp.WithString("template_metadata",
 			mcp.Description("JSON object defining template parameters as key-value pairs where values are empty strings (e.g., {\"TokenName\": \"\", \"TokenSymbol\": \"\"})"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment results now include a rendered_contract field showing the finalized contract code used for deployment (for Ethereum, this is the rendered Solidity; for non-Ethereum, it reflects the original template code).

* **Documentation**
  * Clarified the template_code parameter description: contract owner info isn’t required at template creation and will be set during deployment; if unspecified, msg.sender will be used as the owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->